### PR TITLE
Adding support for other schema(s)

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -2,24 +2,28 @@
 import { Knex } from "knex";
 import type { Writable } from "stream";
 export declare type Options = {
-    /**
-     * Filename or output stream where the type definitions needs to be written.
-     */
-    output: Writable | string;
-    /**
-     * Name overrides for enums, classes, and fields.
-     *
-     * @example
-     *   {
-     *     overrides: { "identity_provider.linkedin": "LinkedIn" }
-     *   }
-     */
-    overrides?: Record<string, string>;
-    prefix?: string;
-    includedSchemas?: string[];
+  /**
+   * Filename or output stream where the type definitions needs to be written.
+   */
+  output: Writable | string;
+  /**
+   * Name overrides for enums, classes, and fields.
+   *
+   * @example
+   *   {
+   *     overrides: { "identity_provider.linkedin": "LinkedIn" }
+   *   }
+   */
+  overrides?: Record<string, string>;
+  prefix?: string;
+  includedSchemas?: string[];
 };
 /**
  * Generates TypeScript definitions (types) from a PostgreSQL database schema.
  */
 export declare function updateTypes(db: Knex, options: Options): Promise<void>;
-export declare function getType(udt: string, customTypes: Map<string, string>, defaultValue: string | null): string;
+export declare function getType(
+  udt: string,
+  customTypes: Map<string, string>,
+  defaultValue: string | null
+): string;

--- a/main.d.ts
+++ b/main.d.ts
@@ -16,6 +16,7 @@ export declare type Options = {
      */
     overrides?: Record<string, string>;
     prefix?: string;
+    includedSchemas?: string[];
 };
 /**
  * Generates TypeScript definitions (types) from a PostgreSQL database schema.

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+  value: true,
 });
 exports.updateTypes = updateTypes;
 exports.getType = getType;
@@ -12,7 +12,9 @@ var _upperFirst2 = _interopRequireDefault(require("lodash/upperFirst"));
 
 var _fs = _interopRequireDefault(require("fs"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
 
 /* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
 
@@ -24,12 +26,24 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 async function updateTypes(db, options) {
   var _options$overrides;
 
-  const overrides = (_options$overrides = options.overrides) !== null && _options$overrides !== void 0 ? _options$overrides : {};
-  const output = typeof options.output === "string" ? _fs.default.createWriteStream(options.output, {
-    encoding: "utf-8"
-  }) : options.output;
-  ["// The TypeScript definitions below are automatically generated.\n", "// Do not touch them, or risk, your modifications being lost.\n\n"].forEach(line => output.write(line));
-  const schemas = options.includedSchemas ? [...options.includedSchemas] : ['public'];
+  const overrides =
+    (_options$overrides = options.overrides) !== null &&
+    _options$overrides !== void 0
+      ? _options$overrides
+      : {};
+  const output =
+    typeof options.output === "string"
+      ? _fs.default.createWriteStream(options.output, {
+          encoding: "utf-8",
+        })
+      : options.output;
+  [
+    "// The TypeScript definitions below are automatically generated.\n",
+    "// Do not touch them, or risk, your modifications being lost.\n\n",
+  ].forEach((line) => output.write(line));
+  const schemas = options.includedSchemas
+    ? [...options.includedSchemas]
+    : ["public"];
 
   if (options.prefix) {
     output.write(options.prefix);
@@ -38,7 +52,12 @@ async function updateTypes(db, options) {
 
   try {
     // Fetch the list of custom enum types
-    const enums = await db.table("pg_type").join("pg_enum", "pg_enum.enumtypid", "pg_type.oid").orderBy("pg_type.typname").orderBy("pg_enum.enumsortorder").select("pg_type.typname as key", "pg_enum.enumlabel as value"); // Construct TypeScript enum types
+    const enums = await db
+      .table("pg_type")
+      .join("pg_enum", "pg_enum.enumtypid", "pg_type.oid")
+      .orderBy("pg_type.typname")
+      .orderBy("pg_enum.enumsortorder")
+      .select("pg_type.typname as key", "pg_enum.enumlabel as value"); // Construct TypeScript enum types
 
     enums.forEach((x, i) => {
       var _overrides$;
@@ -47,35 +66,73 @@ async function updateTypes(db, options) {
       if (!(enums[i - 1] && enums[i - 1].key === x.key)) {
         var _overrides$x$key;
 
-        const enumName = (_overrides$x$key = overrides[x.key]) !== null && _overrides$x$key !== void 0 ? _overrides$x$key : (0, _upperFirst2.default)((0, _camelCase2.default)(x.key));
+        const enumName =
+          (_overrides$x$key = overrides[x.key]) !== null &&
+          _overrides$x$key !== void 0
+            ? _overrides$x$key
+            : (0, _upperFirst2.default)((0, _camelCase2.default)(x.key));
         output.write(`export enum ${enumName} {\n`);
       } // Enum body
 
-
-      const key = (_overrides$ = overrides[`${x.key}.${x.value}`]) !== null && _overrides$ !== void 0 ? _overrides$ : (0, _upperFirst2.default)((0, _camelCase2.default)(x.value.replace(/[.-]/g, "_")));
+      const key =
+        (_overrides$ = overrides[`${x.key}.${x.value}`]) !== null &&
+        _overrides$ !== void 0
+          ? _overrides$
+          : (0, _upperFirst2.default)(
+              (0, _camelCase2.default)(x.value.replace(/[.-]/g, "_"))
+            );
       output.write(`  ${key} = "${x.value}",\n`); // The closing line
 
       if (!(enums[i + 1] && enums[i + 1].key === x.key)) {
         output.write("}\n\n");
       }
     });
-    const enumsMap = new Map(enums.map(x => {
-      var _overrides$x$key2;
+    const enumsMap = new Map(
+      enums.map((x) => {
+        var _overrides$x$key2;
 
-      return [x.key, (_overrides$x$key2 = overrides[x.key]) !== null && _overrides$x$key2 !== void 0 ? _overrides$x$key2 : (0, _upperFirst2.default)((0, _camelCase2.default)(x.key))];
-    })); // Fetch the list of tables/columns
+        return [
+          x.key,
+          (_overrides$x$key2 = overrides[x.key]) !== null &&
+          _overrides$x$key2 !== void 0
+            ? _overrides$x$key2
+            : (0, _upperFirst2.default)((0, _camelCase2.default)(x.key)),
+        ];
+      })
+    ); // Fetch the list of tables/columns
 
-    const columns = await db.withSchema("information_schema").table("columns").whereIn('table_schema', schemas).orderBy("table_schema").orderBy("table_name").orderBy("ordinal_position").select("table_schema as schema", "table_name as table", "column_name as column", db.raw("(is_nullable = 'YES') as nullable"), "column_default as default", "data_type as type", "udt_name as udt"); // The list of database tables as enum
+    const columns = await db
+      .withSchema("information_schema")
+      .table("columns")
+      .whereIn("table_schema", schemas)
+      .orderBy("table_schema")
+      .orderBy("table_name")
+      .orderBy("ordinal_position")
+      .select(
+        "table_schema as schema",
+        "table_name as table",
+        "column_name as column",
+        db.raw("(is_nullable = 'YES') as nullable"),
+        "column_default as default",
+        "data_type as type",
+        "udt_name as udt"
+      ); // The list of database tables as enum
 
     output.write("export enum Table {\n");
-    const tableSet = new Set(columns.map(x => {
-      const schema = x.schema !== 'public' ? `${x.schema}.` : '';
-      return `${schema}${x.table}`;
-    }));
-    Array.from(tableSet).forEach(value => {
+    const tableSet = new Set(
+      columns.map((x) => {
+        const schema = x.schema !== "public" ? `${x.schema}.` : "";
+        return `${schema}${x.table}`;
+      })
+    );
+    Array.from(tableSet).forEach((value) => {
       var _overrides$value;
 
-      const key = (_overrides$value = overrides[value]) !== null && _overrides$value !== void 0 ? _overrides$value : (0, _upperFirst2.default)((0, _camelCase2.default)(value));
+      const key =
+        (_overrides$value = overrides[value]) !== null &&
+        _overrides$value !== void 0
+          ? _overrides$value
+          : (0, _upperFirst2.default)((0, _camelCase2.default)(value));
       output.write(`  ${key} = "${value}",\n`);
     });
     output.write("}\n\n"); // Construct TypeScript db record types
@@ -84,12 +141,22 @@ async function updateTypes(db, options) {
       if (!(columns[i - 1] && columns[i - 1].table === x.table)) {
         var _overrides$x$table;
 
-        const tableName = (_overrides$x$table = overrides[x.table]) !== null && _overrides$x$table !== void 0 ? _overrides$x$table : (0, _upperFirst2.default)((0, _camelCase2.default)(x.table));
-        const schemaName = x.schema !== 'public' ? (0, _upperFirst2.default)((0, _camelCase2.default)(x.schema)) : '';
+        const tableName =
+          (_overrides$x$table = overrides[x.table]) !== null &&
+          _overrides$x$table !== void 0
+            ? _overrides$x$table
+            : (0, _upperFirst2.default)((0, _camelCase2.default)(x.table));
+        const schemaName =
+          x.schema !== "public"
+            ? (0, _upperFirst2.default)((0, _camelCase2.default)(x.schema))
+            : "";
         output.write(`export type ${schemaName}${tableName} = {\n`);
       }
 
-      let type = x.type === "ARRAY" ? `${getType(x.udt.substring(1), enumsMap, x.default)}[]` : getType(x.udt, enumsMap, x.default);
+      let type =
+        x.type === "ARRAY"
+          ? `${getType(x.udt.substring(1), enumsMap, x.default)}[]`
+          : getType(x.udt, enumsMap, x.default);
 
       if (x.nullable) {
         type += " | null";
@@ -169,6 +236,9 @@ function getType(udt, customTypes, defaultValue) {
       return "PostgresInterval";
 
     default:
-      return (_customTypes$get = customTypes.get(udt)) !== null && _customTypes$get !== void 0 ? _customTypes$get : "unknown";
+      return (_customTypes$get = customTypes.get(udt)) !== null &&
+        _customTypes$get !== void 0
+        ? _customTypes$get
+        : "unknown";
   }
 }

--- a/main.js
+++ b/main.js
@@ -22,13 +22,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * Generates TypeScript definitions (types) from a PostgreSQL database schema.
  */
 async function updateTypes(db, options) {
-  var _options$overrides;
+  var _options$overrides, _options$includedSche;
 
   const overrides = (_options$overrides = options.overrides) !== null && _options$overrides !== void 0 ? _options$overrides : {};
   const output = typeof options.output === "string" ? _fs.default.createWriteStream(options.output, {
     encoding: "utf-8"
   }) : options.output;
   ["// The TypeScript definitions below are automatically generated.\n", "// Do not touch them, or risk, your modifications being lost.\n\n"].forEach(line => output.write(line));
+  const schemas = (_options$includedSche = options.includedSchemas) !== null && _options$includedSche !== void 0 ? _options$includedSche : ['public'];
 
   if (options.prefix) {
     output.write(options.prefix);
@@ -64,7 +65,7 @@ async function updateTypes(db, options) {
       return [x.key, (_overrides$x$key2 = overrides[x.key]) !== null && _overrides$x$key2 !== void 0 ? _overrides$x$key2 : (0, _upperFirst2.default)((0, _camelCase2.default)(x.key))];
     })); // Fetch the list of tables/columns
 
-    const columns = await db.withSchema("information_schema").table("columns").where("table_schema", "public").orderBy("table_name").orderBy("ordinal_position").select("table_name as table", "column_name as column", db.raw("(is_nullable = 'YES') as nullable"), "column_default as default", "data_type as type", "udt_name as udt"); // The list of database tables as enum
+    const columns = await db.withSchema("information_schema").table("columns").whereIn('table_schema', schemas).orderBy("table_name").orderBy("ordinal_position").select("table_name as table", "column_name as column", db.raw("(is_nullable = 'YES') as nullable"), "column_default as default", "data_type as type", "udt_name as udt"); // The list of database tables as enum
 
     output.write("export enum Table {\n");
     Array.from(new Set(columns.map(x => x.table))).forEach(value => {

--- a/main.test.ts
+++ b/main.test.ts
@@ -57,6 +57,10 @@ beforeAll(async function setup() {
     table.specificType("interval", "interval").notNullable();
   });
 
+  await db.schema.createTable("login", (table) => {
+    table.increments("secret").notNullable().primary();
+  });
+
     await db.schema.withSchema('log')
         .createTable("messages", (table) => {
         table.increments("int").notNullable().primary();
@@ -77,7 +81,8 @@ test("updateTypes", async function () {
 
   const prefix = 'import { PostgresInterval} from "postgres-interval";';
   const includedSchemas = ['public', 'log']
-  await updateTypes(db, { output, overrides, prefix, includedSchemas });
+  const skipTables = ['login']
+  await updateTypes(db, { output, overrides, prefix, includedSchemas, skipTables });
 
   expect(await toString(output)).toMatchInlineSnapshot(`
     "// The TypeScript definitions below are automatically generated.

--- a/main.test.ts
+++ b/main.test.ts
@@ -61,12 +61,17 @@ beforeAll(async function setup() {
     table.increments("secret").notNullable().primary();
   });
 
-    await db.schema.withSchema('log')
-        .createTable("messages", (table) => {
-        table.increments("int").notNullable().primary();
-        table.text("notes");
-        table.timestamp("timestamp").notNullable();
-    });
+  await db.schema.withSchema("log").createTable("messages", (table) => {
+    table.increments("int").notNullable().primary();
+    table.text("notes");
+    table.timestamp("timestamp").notNullable();
+  });
+
+  await db.schema.withSchema("secret").createTable("secret", (table) => {
+    table.increments("int").notNullable().primary();
+    table.text("notes");
+    table.timestamp("timestamp").notNullable();
+  });
 });
 
 afterAll(async function teardown() {
@@ -80,9 +85,15 @@ test("updateTypes", async function () {
   };
 
   const prefix = 'import { PostgresInterval} from "postgres-interval";';
-  const includedSchemas = ['public', 'log']
-  const skipTables = ['login']
-  await updateTypes(db, { output, overrides, prefix, includedSchemas, skipTables });
+  const includedSchemas = ["public", "log", "!secret"];
+  const skipTables = ["login"];
+  await updateTypes(db, {
+    output,
+    overrides,
+    prefix,
+    schemas: includedSchemas,
+    skip: skipTables,
+  });
 
   expect(await toString(output)).toMatchInlineSnapshot(`
     "// The TypeScript definitions below are automatically generated.
@@ -172,8 +183,10 @@ async function createDatabase(): Promise<void> {
 
   await db.schema.raw("DROP SCHEMA IF EXISTS public CASCADE");
   await db.schema.raw("DROP SCHEMA IF EXISTS log CASCADE");
+  await db.schema.raw("DROP SCHEMA IF EXISTS secret CASCADE");
   await db.schema.raw("CREATE SCHEMA public");
   await db.schema.raw("CREATE SCHEMA log");
+  await db.schema.raw("CREATE SCHEMA secret");
   await db.raw(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
   await db.raw(`CREATE EXTENSION IF NOT EXISTS "hstore"`);
   await db.raw(`CREATE EXTENSION IF NOT EXISTS "citext"`);

--- a/main.ts
+++ b/main.ts
@@ -25,6 +25,8 @@ export type Options = {
   prefix?: string;
 
   includedSchemas?: string[];
+
+  skipTables?: string[];
 };
 
 /**
@@ -43,6 +45,7 @@ export async function updateTypes(db: Knex, options: Options): Promise<void> {
   ].forEach((line) => output.write(line));
 
   const schemas: string[] = options.includedSchemas ? [...options.includedSchemas] : ['public'];
+  const skipTables: string[] = options.skipTables ?? [];
 
   if (options.prefix) {
     output.write(options.prefix);
@@ -90,6 +93,7 @@ export async function updateTypes(db: Knex, options: Options): Promise<void> {
       .withSchema("information_schema")
       .table("columns")
       .whereIn('table_schema', schemas)
+      .whereNotIn('table_name', skipTables)
       .orderBy("table_schema")
       .orderBy("table_name")
       .orderBy("ordinal_position")


### PR DESCRIPTION
Schema name will be prepended to all schema(s) other than public. This will support having the same table name in public and in other schema(s).

Note that public will still not be appended to the tables in the public schema.