### PR TITLE
Adds support for converting column names to camelCase

### DIFF
--- a/main.test.ts
+++ b/main.test.ts
@@ -163,6 +163,92 @@ test("updateTypes", async function () {
   `);
 });
 
+test("updateTypes with camelCaseColumnNames", async function () {
+  const output = new PassThrough();
+  const overrides = {
+    "identity_provider.linkedin": "LinkedIn",
+  };
+
+  await updateTypes(db, {
+    output,
+    overrides,
+    prefix: 'import { PostgresInterval} from "postgres-interval";',
+    schema: ["public", "log", "!secret"],
+    exclude: ["login"],
+    camelCaseColumnNames: true,
+  });
+
+  expect(await toString(output)).toMatchInlineSnapshot(`
+    "// The TypeScript definitions below are automatically generated.
+    // Do not touch them, or risk, your modifications being lost.
+
+    import { PostgresInterval} from \\"postgres-interval\\";
+
+    export enum IdentityProvider {
+      Google = \\"google\\",
+      Facebook = \\"facebook\\",
+      LinkedIn = \\"linkedin\\",
+    }
+
+    export enum Table {
+      LogMessages = \\"log.messages\\",
+      User = \\"user\\",
+    }
+
+    export type LogMessages = {
+      int: number;
+      notes: string | null;
+      timestamp: Date;
+    };
+
+    export type User = {
+      int: number;
+      provider: IdentityProvider;
+      providerNull: IdentityProvider | null;
+      providerArray: IdentityProvider[];
+      intArray: number[];
+      shortId: string;
+      decimal: string;
+      decimalArray: string[];
+      double: number;
+      doubleArray: number[];
+      float: number;
+      floatArray: number[];
+      money: string;
+      bigint: string;
+      binary: Buffer;
+      binaryNull: Buffer | null;
+      binaryArray: Buffer[];
+      uuid: string;
+      uuidNull: string | null;
+      uuidArray: string[];
+      text: string;
+      textNull: string | null;
+      textArray: string[];
+      citext: string;
+      citextNull: string | null;
+      citextArray: string[];
+      char: string;
+      varchar: string;
+      bool: boolean;
+      boolNull: boolean | null;
+      boolArray: boolean[];
+      jsonbObject: Record<string, unknown>;
+      jsonbObjectNull: Record<string, unknown> | null;
+      jsonbArray: unknown[];
+      jsonbArrayNull: unknown[] | null;
+      timestamp: Date;
+      timestampNull: Date | null;
+      time: string;
+      timeNull: string | null;
+      timeArray: string[];
+      interval: PostgresInterval;
+    };
+
+    "
+  `);
+});
+
 async function createDatabase(): Promise<void> {
   try {
     await db.select(db.raw("version()")).first();

--- a/main.ts
+++ b/main.ts
@@ -50,6 +50,14 @@ export type Options = {
    *   exclude: ["migration", "migration_lock"]
    */
   exclude?: string[] | string;
+
+  /**
+   * Whether to convert column names to camel case.
+   *
+   * @example
+   *   camelCaseColumnNames: true
+   */
+  camelCaseColumnNames?: boolean;
 };
 
 /**
@@ -177,7 +185,11 @@ export async function updateTypes(db: Knex, options: Options): Promise<void> {
         type += " | null";
       }
 
-      output.write(`  ${x.column}: ${type};\n`);
+      const columnName = options.camelCaseColumnNames
+        ? camelCase(x.column)
+        : x.column;
+
+      output.write(`  ${columnName}: ${type};\n`);
 
       if (!(columns[i + 1] && columns[i + 1].table === x.table)) {
         output.write("};\n\n");


### PR DESCRIPTION
This adds a support for passing column name through `camelCase` from `lodash` during file generation.

Not sure about the configuration option tho, please let me know if you have a different vision.