### PR TITLE
Add column name escaping (#10)

### DIFF
--- a/main.test.ts
+++ b/main.test.ts
@@ -55,6 +55,9 @@ beforeAll(async function setup() {
     table.time("time_null");
     table.specificType("time_array", "time[]").notNullable();
     table.specificType("interval", "interval").notNullable();
+    table.text("display name");
+    table.text("1invalidIdentifierName");
+    table.text(`name with a "`);
   });
 
   await db.schema.createTable("login", (table) => {
@@ -158,6 +161,9 @@ test("updateTypes", async function () {
       time_null: string | null;
       time_array: string[];
       interval: PostgresInterval;
+      \\"display name\\": string | null;
+      \\"1invalidIdentifierName\\": string | null;
+      \\"name with a \\\\\\"\\": string | null;
     };
 
     // user supplied suffix

--- a/main.ts
+++ b/main.ts
@@ -178,7 +178,7 @@ export async function updateTypes(db: Knex, options: Options): Promise<void> {
         type += " | null";
       }
 
-      output.write(`  ${x.column}: ${type};\n`);
+      output.write(`  ${quoteColumnName(x.column)}: ${type};\n`);
 
       if (!(columns[i + 1] && columns[i + 1].table === x.table)) {
         output.write("};\n\n");
@@ -267,4 +267,12 @@ export function getType(
     default:
       return customTypes.get(udt) ?? "unknown";
   }
+}
+
+function quoteColumnName(name: string): string {
+  // regex is a simplified check for valid IdentifierNames
+  const isValidIdentifier = /^[a-zA-Z$_][a-zA-Z$_0-9]*$/.test(name);
+
+  // also escape any quotes that might be in the name.
+  return isValidIdentifier ? name : JSON.stringify(name);
 }


### PR DESCRIPTION
I'm not an expert at these things. We originally talked about just quoting spaces, but I realized that non-identifiers need to also be escaped. I'm also not sure if JSON is the best way to quote/escape a string in this context.

I don't care about an exact check for identifiers (valid unicode) because I don't mind if we add quotes where not needed. I just didn't want to add quotes to everything.