### PR TITLE
Fix: Support PGSQL Decimal type

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -228,7 +228,6 @@ export function getType(
     case "text":
     case "citext":
     case "money":
-    case "numeric":
     case "int8":
     case "char":
     case "character":
@@ -251,6 +250,7 @@ export function getType(
     case "float":
     case "float4":
     case "float8":
+    case "numeric":
       return "number";
     case "date":
     case "timestamp":


### PR DESCRIPTION
I've noticed that DB schemas containing fields defined as `DECIMAL` generate types as `strings`. Here's an example:

```
CREATE TABLE booking_pricing
(
    id     INT NOT NULL GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
    total_price            DECIMAL(15,4)           NOT NULL,
)
```
produces:

```
export type BookingPricing = {
  id: number;
  total_price: string;
};
```
instead of :

```
export type BookingPricing = {
  id: number;
  total_price: number;
};
```