### PR TITLE
feat: Add support for int2 extension integer type

### DIFF
--- a/main.test.ts
+++ b/main.test.ts
@@ -28,6 +28,10 @@ beforeAll(async function setup() {
     table.specificType("float_array", "float4[]").notNullable();
     table.specificType("money", "money").notNullable();
     table.bigInteger("bigint").notNullable();
+    table.smallint("smallint").notNullable();
+    table.specificType("int2", "int2").notNullable();
+    table.specificType("int4", "int4").notNullable();
+    table.specificType("int8", "int8").notNullable();
     table.binary("binary").notNullable();
     table.binary("binary_null");
     table.specificType("binary_array", "bytea[]").notNullable();
@@ -139,6 +143,10 @@ test("updateTypes", async function () {
       float_array: number[];
       money: string;
       bigint: string;
+      smallint: number;
+      int2: number;
+      int4: number;
+      int8: string;
       binary: Buffer;
       binary_null: Buffer | null;
       binary_array: Buffer[];

--- a/main.ts
+++ b/main.ts
@@ -246,6 +246,7 @@ export function getType(
     case "smallint":
     case "integer":
     case "int":
+    case "int2":
     case "int4":
     case "real":
     case "float":


### PR DESCRIPTION
I noticed that the `int2` [extension integer type](https://www.postgresql.org/docs/current/datatype-numeric.html) wasn't mapped to `number`. I also took the liberty to add test assertions for the other integer types (`smallint`, `int4` and `int8`).